### PR TITLE
fix: quote schedule fix starting asterisk

### DIFF
--- a/templates/cron.yaml
+++ b/templates/cron.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "rclone.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.schedule }}
+  schedule: {{ .Values.schedule | quote }}
   {{- if hasKey .Values "suspend" }}
   suspend: {{ .Values.suspend }}
   {{- end }}


### PR DESCRIPTION
If schedule starts when an asterisk then you get this error:
```
Error: YAML parse error on rclone/templates/cron.yaml: error converting YAML to JSON: yaml: line 12: did not find expected alphabetic or numeric character
```

As explained in https://stackoverflow.com/a/71176695

The fix is to quote the schedule.