### PR TITLE
fix: timezone not applied because of inconsistence case

### DIFF
--- a/templates/cron.yaml
+++ b/templates/cron.yaml
@@ -9,8 +9,8 @@ spec:
   {{- if hasKey .Values "suspend" }}
   suspend: {{ .Values.suspend }}
   {{- end }}
-  {{- if .Values.timezone }}
-  timeZone: {{ .Values.timezone | quote }}
+  {{- if .Values.timeZone }}
+  timeZone: {{ .Values.timeZone | quote }}
   {{- end }}
   concurrencyPolicy: {{ .Values.concurrencyPolicy }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}


### PR DESCRIPTION
I tried to change timezone via yaml, but it wasn't applied.
But when when I tried it via --set helm arguments (ex: --set timezone=Asia/Jakarta), it's working.


I realized that there was an inconsistence in values.yaml :
```
timeZone: ""
```

and templates/cron.yaml : 
```
{{- if .Values.timezone }}
timeZone: {{ .Values.timezone | quote }}
{{- end }}
```